### PR TITLE
set state to directory

### DIFF
--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -2,6 +2,7 @@
 - name: create ansible folder, if not already there. For next steps.
   file:
     path: /etc/ansible
+    state: directory
 
 - name: Ubuntu16.04/Systemd/Cloud combination requires minimum one reboot, regardless of ansible, in order for this to work.
   shell: touch /etc/ansible/rebooted-once.txt


### PR DESCRIPTION
Ansible (Version 2.5.2) was throwing an error at task "create ansible folder, if not already there. For next steps.".

![ansible-error](https://user-images.githubusercontent.com/7050283/46208433-ff0ec180-c32a-11e8-9184-cce18194376b.png)

With the state set to directory it completes the role successfully!
