### PR TITLE
Make "export XKL_XMODMAP_DISABLE=1" in xstartup.j2 conditional

### DIFF
--- a/templates/xstartup.j2
+++ b/templates/xstartup.j2
@@ -3,7 +3,9 @@
 #{{ ansible_managed }}
 {% endif %}
 
+{% if vnc_desktop == "gnome" %}
 export XKL_XMODMAP_DISABLE=1
+{% endif %}
 unset SESSION_MANAGER
 unset DBUS_SESSION_BUS_ADDRESS
 


### PR DESCRIPTION
When using _xfce4_, the GNOME related `export XKL_XMODMAP_DISABLE=1`in the _xstartup_ file breaks functionality over VNC (such as icons functioning). Tested without this in the _xstartup_ file and it works as expected using xfce4.

Thanks for the great work with this project, it is very helpful!