### PR TITLE
Support Ubuntu 23

### DIFF
--- a/vars/Ubuntu-23.yml
+++ b/vars/Ubuntu-23.yml
@@ -1,0 +1,40 @@
+---
+default_vnc_server: tigervnc
+
+default_vnc_users:
+  - username: ubuntu
+    usergroup: ubuntu
+    # port 5901 is 1
+    vnc_num: 1
+    vnc_default_password: mypassword
+default_vnc_desktop_packages:
+  gnome:
+    - ubuntu-desktop
+    - gnome-panel
+    - gnome-settings-daemon
+    - metacity
+    - nautilus
+    - gnome-terminal
+    - xterm
+  xfce4:
+    - xfce4
+    - gnome-icon-theme
+    - gnome-terminal
+    - firefox
+    - xterm
+
+default_vnc_server_packages:
+  tigervnc:
+    - libtasn1-bin
+    # - libtasn1-3-bin
+    - tigervnc-standalone-server
+    - tigervnc-common
+  vnc4server:
+    - vnc4server
+  tightvnc:
+    - tightvncserver
+
+default_xstartup_additional_command1: dbus-update-activation-environment --systemd --all
+
+# use /usr/share/xsessions/ubuntu.desktop
+default_vnc_desktop_gnome_override: ubuntu


### PR DESCRIPTION
This adds default configuration for Ubuntu 23, copied from [`vars/Ubuntu-22.yml`](https://github.com/sdarwin/Ansible-VNC/blob/master/vars/Ubuntu-22.yml).

I have tested this locally with tigervnc and gnome. I tried testing `vnc4server` but installing the package fails—from what I can tell there hasn't been a `vnc4server` package available since Ubuntu 18. `tightvnc` installs cleanly but I didn't test the entire setup.

Should fix #25 